### PR TITLE
Add documentation to run as a service on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,76 @@ python src/logalert.py
 ```
 
 The script will start monitoring the specified log file for the given keywords and send notifications to the configured ntfy endpoint when any of the keywords are found in the log file.
+
+## Running as a Service on Linux
+
+### Creating a Virtual Environment and Installing Dependencies
+
+1. Create a virtual environment:
+
+```sh
+python3 -m venv /path/to/new/virtual/environment
+```
+
+2. Activate the virtual environment:
+
+```sh
+source /path/to/new/virtual/environment/bin/activate
+```
+
+3. Install the required dependencies:
+
+```sh
+pip install -r requirements.txt
+```
+
+### Sample `systemd` Service File
+
+Create a file named `logalert.service` with the following content:
+
+```ini
+[Unit]
+Description=LogAlert Service
+After=network.target
+
+[Service]
+User=your-username
+WorkingDirectory=/path/to/your/project
+ExecStart=/path/to/new/virtual/environment/bin/python /path/to/your/project/src/logalert.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Enabling and Starting the Service
+
+1. Copy the `logalert.service` file to the systemd directory:
+
+```sh
+sudo cp logalert.service /etc/systemd/system/
+```
+
+2. Reload the systemd daemon to recognize the new service:
+
+```sh
+sudo systemctl daemon-reload
+```
+
+3. Enable the service to start on boot:
+
+```sh
+sudo systemctl enable logalert.service
+```
+
+4. Start the service:
+
+```sh
+sudo systemctl start logalert.service
+```
+
+5. Check the status of the service:
+
+```sh
+sudo systemctl status logalert.service
+```

--- a/logalert.service
+++ b/logalert.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=LogAlert Service
+After=network.target
+
+[Service]
+User=your-username
+WorkingDirectory=/path/to/your/project
+ExecStart=/path/to/new/virtual/environment/bin/python /path/to/your/project/src/logalert.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add documentation for running the service on a Linux system inside a virtual environment.

* **README.md**
  - Add a new section titled "Running as a Service on Linux".
  - Include instructions for creating a virtual environment and installing dependencies.
  - Provide a sample `systemd` service file for running the script as a service.
  - Include steps to enable and start the service.

* **logalert.service**
  - Create a sample `systemd` service file for running the script as a service.
  - Include configuration for running the script inside a virtual environment.
  - Set the service to restart on failure.
  - Specify the working directory and user for the service.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Mekcyed/logalert-ntfy/pull/4?shareId=ca0080a0-976d-4d12-a078-4cefa2a15398).